### PR TITLE
fix(ui): not using full width for conversational view and input textarea

### DIFF
--- a/src/components/ConversationView.vue
+++ b/src/components/ConversationView.vue
@@ -28,7 +28,7 @@ watch(() => [props.messages, props.messages.at(-1)!.content], () => {
   <div class="relative flex-1 overflow-hidden">
     <div
       ref="containerRef"
-      class="absolute inset-0 overflow-y-auto p-4 space-y-4"
+      class="absolute inset-0 mx-auto max-w-screen-lg overflow-y-auto p-4 space-y-4"
     >
       <template v-for="message in messages" :key="message.id">
         <div

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -305,18 +305,15 @@ onMounted(() => {
     v-if="currentMode === ChatMode.CONVERSATION"
     :messages="currentBranch.messages"
   />
-  <div class="relative flex bg-white p-2 dark:bg-dark" shadow="lg current">
+  <div class="relative flex bg-neutral-100 p-2 dark:bg-neutral-900" shadow="lg" mx-auto w-full max-w-screen-md rounded-lg>
     <BasicTextarea
       v-model="inputMessage"
-      placeholder="Enter to send message, Shift+Enter for new-line"
-      outline="none"
-      max-h-60vh w-full resize-none border-gray-300 rounded-lg p-2 px-3 py-2 dark:bg-dark-50 focus:ring-2 focus:ring-black dark:focus:ring-white
-      transition="all duration-200 ease-in-out"
-      @submit="handleSendButton"
+      placeholder="Enter to send message, Shift+Enter for new-line" outline="none" w-full
+      resize-none border-gray-300 rounded-sm p-2 px-3 py-2 dark:bg-neutral-800 focus:ring-2
+      focus:ring-black dark:focus:ring-white transition="all duration-200 ease-in-out" @submit="handleSendButton"
     />
     <div
-      v-if="showModelSelector"
-      ref="modelSelectorRef"
+      v-if="showModelSelector" ref="modelSelectorRef"
       class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-full overflow-y-auto border border-gray-300 rounded-lg bg-white dark:border-gray-700 dark:bg-dark-50"
       style="max-height: 300px;"
     >


### PR DESCRIPTION
<img width="2953" alt="image" src="https://github.com/user-attachments/assets/882416f6-2d11-4bdc-b1fa-e0298c857fca" />

<img width="2953" alt="image" src="https://github.com/user-attachments/assets/5f93d8c1-efac-4a30-9e83-4a3e03ef1136" />

<img width="2953" alt="image" src="https://github.com/user-attachments/assets/c8245062-64bf-4fe4-9b96-87a72c481201" />

<img width="2953" alt="image" src="https://github.com/user-attachments/assets/7f75e7a3-28cb-4115-a84f-bdd73b261c1a" />
