### PR TITLE
fix: pre-bundle duckdb-wasm package under dev mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -117,8 +117,8 @@ export default defineConfig({
   },
 
   optimizeDeps: {
+    include: ['@proj-airi/duckdb-wasm'],
     exclude: [
-      '@proj-airi/duckdb-wasm',
       '@proj-airi/drizzle-duckdb-wasm',
       '@proj-airi/drizzle-duckdb-wasm/*',
     ],


### PR DESCRIPTION
This PR will resolve #37. But it is not guaranteed that this is the only valid way.

### Context
Currently, the error 'Failed to fetch dynamically imported module' will happen whenever we create a conversation in the app (not sure if this happens for every machine under dev mode).

### Reason
The root cause points to the package **"@proj-airi/duckdb-wasm"**, which seems to use some WASM-related things behind. So I don't think Vite can handle it quite well without pre-bundling. 