### PR TITLE
fix(tutorial): remove redundant 'Reset' step in firstHere tutorial

### DIFF
--- a/src/stores/tutorial.ts
+++ b/src/stores/tutorial.ts
@@ -253,8 +253,8 @@ export const useTutorialStore = defineStore('tutorial', () => {
   ], driverObj, activeTutorial))
 
   const firstHere = shallowRef(useTutorial('tutorial/firstHereDriver', [
-    ...settings.value.steps,
-    ...chat.value.steps,
+    ...settings.value.steps.slice(0, -1),
+    ...chat.value.steps.slice(0, -1),
     lastStep,
   ], driverObj, activeTutorial))
 


### PR DESCRIPTION
Closes #65 