### PR TITLE
feat: support multi modality input

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,3 +12,9 @@ intro:
   aka: Also known as
   whats-your-name: What's your name?
 not-found: Not found
+file_upload:
+  drop_hint: Drop files here or click to upload
+  size_exceeded: File size exceeds {size}MB limit
+  invalid_type: Invalid file type. Only images are supported.
+  max_files_exceeded: Maximum {max} files allowed
+  read_error: Failed to read file

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -12,3 +12,9 @@ intro:
   aka: 也叫
   whats-your-name: 输入你的名字
 not-found: 未找到页面
+file_upload:
+  drop_hint: 拖放文件到此处或点击上传
+  size_exceeded: 文件大小超过 {size}MB 限制
+  invalid_type: 无效的文件类型，仅支持图片
+  max_files_exceeded: 最多允许 {max} 个文件
+  read_error: 文件读取失败

--- a/src/components/AttachmentDisplay.vue
+++ b/src/components/AttachmentDisplay.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import type { Attachment } from '~/types/attachment'
+import { ref } from 'vue'
+import { Dialog, DialogContent } from '~/components/ui/dialog'
+
+defineProps<{
+  attachments: Attachment[]
+  compact?: boolean
+}>()
+
+const previewImage = ref<Attachment | null>(null)
+
+function openImagePreview(attachment: Attachment) {
+  if (attachment.type === 'image_url') {
+    previewImage.value = attachment
+  }
+}
+
+function closePreview() {
+  previewImage.value = null
+}
+</script>
+
+<template>
+  <div v-if="attachments.length > 0" class="attachment-display flex flex-wrap gap-2" :class="{ 'mt-2': !compact }">
+    <template v-for="attachment in attachments" :key="attachment.id">
+      <!-- Image attachment -->
+      <div
+        v-if="attachment.type === 'image_url'"
+        class="cursor-pointer overflow-hidden rounded-lg bg-gray-100 transition-transform hover:scale-105 dark:bg-gray-800"
+        :class="compact ? 'h-12 w-12' : 'h-24 w-24'"
+        @click="openImagePreview(attachment)"
+      >
+        <img
+          :src="attachment.image_url.url"
+          :alt="attachment.image_url.url"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        >
+      </div>
+
+      <!-- File attachment -->
+      <div
+        v-else
+        class="flex items-center gap-2 rounded-lg bg-gray-100 px-3 py-2 dark:bg-gray-800"
+      >
+        <div class="i-solar-file-bold text-gray-500" />
+        <span class="max-w-32 truncate text-sm text-gray-700 dark:text-gray-300">{{ attachment.fileName }}</span>
+      </div>
+    </template>
+
+    <!-- Full-size image preview dialog -->
+    <Dialog :open="!!previewImage" @update:open="closePreview">
+      <DialogContent class="max-h-[90vh] max-w-[90vw] overflow-auto p-4">
+        <img
+          v-if="previewImage?.type === 'image_url'"
+          :src="previewImage.image_url.url"
+          :alt="previewImage.image_url.url"
+          class="max-h-[85vh] max-w-full object-contain"
+        >
+      </DialogContent>
+    </Dialog>
+  </div>
+</template>
+
+<style scoped>
+.attachment-display img {
+  transition: transform 0.2s ease;
+}
+</style>

--- a/src/components/ConversationView.vue
+++ b/src/components/ConversationView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import type { Attachment } from '~/types/attachment'
 import type { Message } from '~/types/messages'
 import { useEventListener } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useMessagesStore } from '~/stores/messages'
+import AttachmentDisplay from './AttachmentDisplay.vue'
 import ConversationNodeContextMenu from './ConversationNodeContextMenu.vue'
 import MarkdownView from './MarkdownView.vue'
 import SystemPrompt from './SystemPrompt.vue'
@@ -151,6 +153,10 @@ function handleAbort(messageId: string) {
 useEventListener('click', closeContextMenu)
 
 useEventListener(containerRef, 'scroll', updateShouldAutoScroll)
+
+function getAttachments(message: Message) {
+  return message.content.filter(part => part.type !== 'text') as Attachment[]
+}
 </script>
 
 <template>
@@ -183,6 +189,14 @@ useEventListener(containerRef, 'scroll', updateShouldAutoScroll)
             class="relative min-w-0 flex-1 rounded-lg p-4"
             :class="message.role === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'"
           >
+            <!-- FIXME: get attachments twice, can we optimize this? -->
+            <AttachmentDisplay
+              v-if="getAttachments(message).length > 0"
+              :attachments="getAttachments(message)"
+              compact
+              class="mb-2"
+            />
+
             <MarkdownView
               :content="message.content"
               :dark="message.role === 'user'"

--- a/src/components/FileUpload.vue
+++ b/src/components/FileUpload.vue
@@ -1,0 +1,257 @@
+<script setup lang="ts">
+import type { Attachment } from '~/types/attachment'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue-sonner'
+import { Button } from '~/components/ui/button'
+
+const props = withDefaults(defineProps<{
+  maxFiles?: number
+  maxFileSize?: number // in MB
+  acceptedTypes?: string[]
+}>(), {
+  maxFiles: 5,
+  maxFileSize: 10,
+  acceptedTypes: () => ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+})
+
+const emit = defineEmits<{
+  (e: 'filesChanged', files: Attachment[]): void
+}>()
+
+const { t } = useI18n()
+const fileInputRef = ref<HTMLInputElement>()
+const attachments = ref<Attachment[]>([])
+const isDragging = ref(false)
+
+const acceptString = computed(() => props.acceptedTypes.join(','))
+
+async function processFile(file: File) {
+  // Check file size
+  if (file.size > props.maxFileSize * 1024 * 1024) {
+    throw new Error(t('file_upload.size_exceeded', { size: props.maxFileSize }))
+  }
+
+  // Check file type
+  if (!props.acceptedTypes.includes(file.type)) {
+    throw new Error(t('file_upload.invalid_type'))
+  }
+
+  return new Promise<Attachment>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      const data = event.target?.result as string
+
+      let attachment: Attachment
+
+      // Get image dimensions if it's an image
+      if (file.type.startsWith('image/')) {
+        attachment = {
+          fileName: file.name,
+          id: crypto.randomUUID(),
+          type: 'image_url',
+          image_url: {
+            url: data,
+          },
+        }
+
+        resolve(attachment)
+        return
+      }
+
+      if (file.type.startsWith('audio/')) {
+        if (!['mp3', 'wav'].includes(file.type.split('/')[1] as 'mp3' | 'wav')) {
+          reject(new Error('Invalid audio format'))
+          return
+        }
+
+        attachment = {
+          fileName: file.name,
+          id: crypto.randomUUID(),
+          type: 'input_audio',
+          input_audio: {
+            data,
+            format: file.type.split('/')[1] as 'mp3' | 'wav',
+          },
+        }
+
+        resolve(attachment)
+        return
+      }
+
+      attachment = {
+        fileName: file.name,
+        id: crypto.randomUUID(),
+        type: 'file',
+        file: {
+          file_data: data,
+          filename: file.name,
+        },
+      }
+
+      resolve(attachment)
+    }
+
+    reader.onerror = () => {
+      reject(new Error('Failed to read file'))
+    }
+
+    reader.readAsDataURL(file)
+  })
+}
+
+async function handleFiles(files: FileList | File[]) {
+  const fileArray = Array.from(files)
+
+  // Check max files limit
+  if (attachments.value.length + fileArray.length > props.maxFiles) {
+    toast.error(t('file_upload.max_files_exceeded', { max: props.maxFiles }))
+    return
+  }
+
+  const processedFiles = await Promise.all(fileArray.map(processFile))
+
+  attachments.value = processedFiles
+  emit('filesChanged', attachments.value)
+}
+
+function handleFileInput(event: Event) {
+  const input = event.target as HTMLInputElement
+  if (input.files) {
+    handleFiles(input.files)
+    // Reset input to allow selecting same file again
+    input.value = ''
+  }
+}
+
+function handleDrop(event: DragEvent) {
+  event.preventDefault()
+  isDragging.value = false
+
+  if (event.dataTransfer?.files) {
+    handleFiles(event.dataTransfer.files)
+  }
+}
+
+function handleDragOver(event: DragEvent) {
+  event.preventDefault()
+  isDragging.value = true
+}
+
+function handleDragLeave() {
+  isDragging.value = false
+}
+
+function removeAttachment(id: string) {
+  attachments.value = attachments.value.filter(a => a.id !== id)
+  emit('filesChanged', attachments.value)
+}
+
+function clearAll() {
+  attachments.value = []
+  emit('filesChanged', attachments.value)
+}
+
+function triggerFileInput() {
+  fileInputRef.value?.click()
+}
+
+// Expose methods to parent
+defineExpose({
+  triggerFileInput,
+  clearAll,
+  attachments,
+})
+</script>
+
+<template>
+  <div class="file-upload">
+    <!-- Hidden file input -->
+    <input
+      ref="fileInputRef"
+      type="file"
+      :accept="acceptString"
+      multiple
+      class="hidden"
+      @change="handleFileInput"
+    >
+
+    <!-- Drag and drop zone (shown when there are no attachments or when dragging) -->
+    <div
+      v-if="attachments.length === 0 || isDragging"
+      class="drop-zone border-2 rounded-lg border-dashed p-4 text-center transition-colors"
+      :class="{
+        'border-primary bg-primary/5': isDragging,
+        'border-gray-300 dark:border-gray-600': !isDragging,
+      }"
+      @drop="handleDrop"
+      @dragover="handleDragOver"
+      @dragleave="handleDragLeave"
+      @click="triggerFileInput"
+    >
+      <div class="flex flex-col items-center gap-2 text-gray-500 dark:text-gray-400">
+        <div class="i-solar-upload-square-bold text-2xl" />
+        <span class="text-sm">{{ t('file_upload.drop_hint') }}</span>
+      </div>
+    </div>
+
+    <!-- Attachment previews -->
+    <div v-if="attachments.length > 0" class="attachment-previews mt-2 flex flex-wrap gap-2">
+      <div
+        v-for="attachment in attachments"
+        :key="attachment.id"
+        class="group relative"
+      >
+        <!-- Image preview -->
+        <div
+          v-if="attachment.type === 'image_url'"
+          class="h-16 w-16 overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
+        >
+          <img
+            :src="attachment.image_url.url"
+            :alt="attachment.image_url.url"
+            class="h-full w-full object-cover"
+          >
+        </div>
+
+        <!-- File preview -->
+        <div
+          v-else
+          class="h-16 w-16 flex flex-col items-center justify-center rounded-lg bg-gray-100 p-2 dark:bg-gray-800"
+        >
+          <div class="i-solar-file-bold text-xl text-gray-500" />
+          <span class="mt-1 max-w-full truncate text-xs text-gray-500">{{ attachment.fileName }}</span>
+        </div>
+
+        <!-- Remove button -->
+        <button
+          class="absolute right-[-4px] top-[-4px] h-5 w-5 flex items-center justify-center rounded-full bg-red-500 text-white opacity-0 transition-opacity group-hover:opacity-100"
+          @click.stop="removeAttachment(attachment.id)"
+        >
+          <div class="i-solar-close-circle-bold text-sm" />
+        </button>
+      </div>
+
+      <!-- Add more button -->
+      <Button
+        v-if="attachments.length < maxFiles"
+        variant="outline"
+        size="sm"
+        class="h-16 w-16"
+        @click="triggerFileInput"
+      >
+        <div class="i-solar-add-circle-bold text-xl" />
+      </Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.drop-zone {
+  cursor: pointer;
+}
+
+.drop-zone:hover {
+  @apply border-primary/50;
+}
+</style>

--- a/src/components/nodes/UserNode.vue
+++ b/src/components/nodes/UserNode.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { NodeProps } from '@vue-flow/core'
+import type { Attachment } from '~/types/attachment'
 import type { NodeData } from '~/types/node'
 import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
 import { useSettingsStore } from '~/stores/settings'
 import AttachmentDisplay from '../AttachmentDisplay.vue'
 import MarkdownView from '../MarkdownView.vue'
@@ -10,6 +12,9 @@ import Node from './Node.vue'
 const props = defineProps<NodeProps<NodeData>>()
 
 const { defaultTextModel } = storeToRefs(useSettingsStore())
+const attachments = computed(() => {
+  return props.data.message.content.filter(part => part.type !== 'text') as Attachment[]
+})
 </script>
 
 <template>
@@ -23,12 +28,12 @@ const { defaultTextModel } = storeToRefs(useSettingsStore())
       @{{ data.message.provider }}/{{ data.message.model }}
     </div>
     <div p-2>
-      <!-- <AttachmentDisplay
-        v-if="data.message.attachments && data.message.attachments.length > 0"
-        :attachments="data.message.attachments"
+      <AttachmentDisplay
+        v-if="attachments.length > 0"
+        :attachments="attachments"
         compact
         class="mb-2"
-      /> -->
+      />
       <MarkdownView :content="data.message.content" />
     </div>
   </Node>

--- a/src/components/nodes/UserNode.vue
+++ b/src/components/nodes/UserNode.vue
@@ -3,6 +3,7 @@ import type { NodeProps } from '@vue-flow/core'
 import type { NodeData } from '~/types/node'
 import { storeToRefs } from 'pinia'
 import { useSettingsStore } from '~/stores/settings'
+import AttachmentDisplay from '../AttachmentDisplay.vue'
 import MarkdownView from '../MarkdownView.vue'
 import Node from './Node.vue'
 
@@ -22,6 +23,12 @@ const { defaultTextModel } = storeToRefs(useSettingsStore())
       @{{ data.message.provider }}/{{ data.message.model }}
     </div>
     <div p-2>
+      <!-- <AttachmentDisplay
+        v-if="data.message.attachments && data.message.attachments.length > 0"
+        :attachments="data.message.attachments"
+        compact
+        class="mb-2"
+      /> -->
       <MarkdownView :content="data.message.content" />
     </div>
   </Node>

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -51,7 +51,7 @@ export function useMessageModel() {
     })
   }
 
-  async function create(msg: Omit<Message, 'id'>) {
+  async function create(msg: Omit<typeof schema.messages.$inferInsert, 'id' | 'created_at' | 'updated_at' | 'embedding' | 'show_summary'>) {
     return await dbStore.withCheckpoint((db) => {
       return db.insert(schema.messages).values(msg).returning()
     })

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -196,10 +196,12 @@ async function handleSendButton(messageText?: string) {
   await conversationStore.sendMessage(
     roomId,
     messageToSend,
+    pendingAttachments.value,
     parentId,
     {
       onUserMessageCreated: (messageId) => {
         inputMessage.value = modelPrefix ? `model=${modelPrefix} ` : ''
+        pendingAttachments.value = []
         selectedMessageId.value = messageId
       },
       onAssistantMessageCreated: async (messageId) => {

--- a/src/stores/conversation.ts
+++ b/src/stores/conversation.ts
@@ -230,12 +230,12 @@ export const useConversationStore = defineStore('conversation', () => {
         ],
       }
 
-      const capabilities: Record<string, boolean> = hasCapabilities(
-        provider as ProviderNames,
-        model as ModelIdsByProvider<ProviderNames>,
-        ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
-      )
-      const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
+      // const capabilities: Record<string, boolean> = hasCapabilities(
+      //   provider as ProviderNames,
+      //   model as ModelIdsByProvider<ProviderNames>,
+      //   ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
+      // )
+      // const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
 
       const branch = messagesStore.getBranchById(parentId)
       const conversationMessages = branch.messages
@@ -248,7 +248,7 @@ export const useConversationStore = defineStore('conversation', () => {
       } satisfies BaseMessage, ...conversationMessages]))
 
       const { textStream, reasoningTextStream } = streamText({
-        ...(isSupportTools ? tools : {}),
+        // ...(isSupportTools ? tools : {}),
         maxSteps: 10,
         apiKey: currentProvider.value?.apiKey,
         baseURL: currentProvider.value?.baseURL,

--- a/src/stores/conversation.ts
+++ b/src/stores/conversation.ts
@@ -1,10 +1,10 @@
-import type {
-  CapabilitiesByModel,
-  ModelIdsByProvider,
-  ProviderNames,
-} from '@moeru-ai/jem'
+import type { CapabilitiesByModel, ModelIdsByProvider, ProviderNames } from '@moeru-ai/jem'
 import type { CommonContentPart } from 'xsai'
+import type { Attachment } from '~/types/attachment'
 import type { BaseMessage } from '~/types/messages'
+import {
+  hasCapabilities,
+} from '@moeru-ai/jem'
 import { defineStore, storeToRefs } from 'pinia'
 import { ref } from 'vue'
 import { toast } from 'vue-sonner'
@@ -230,12 +230,12 @@ export const useConversationStore = defineStore('conversation', () => {
         ],
       }
 
-      // const capabilities: Record<string, boolean> = hasCapabilities(
-      //   provider as ProviderNames,
-      //   model as ModelIdsByProvider<ProviderNames>,
-      //   ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
-      // )
-      // const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
+      const capabilities: Record<string, boolean> = hasCapabilities(
+        provider as ProviderNames,
+        model as ModelIdsByProvider<ProviderNames>,
+        ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
+      )
+      const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
 
       const branch = messagesStore.getBranchById(parentId)
       const conversationMessages = branch.messages
@@ -248,7 +248,7 @@ export const useConversationStore = defineStore('conversation', () => {
       } satisfies BaseMessage, ...conversationMessages]))
 
       const { textStream, reasoningTextStream } = streamText({
-        // ...(isSupportTools ? tools : {}),
+        ...(isSupportTools ? tools : {}),
         maxSteps: 10,
         apiKey: currentProvider.value?.apiKey,
         baseURL: currentProvider.value?.baseURL,
@@ -380,6 +380,7 @@ export const useConversationStore = defineStore('conversation', () => {
   async function sendMessage(
     roomId: string,
     messageText: string,
+    attachments: Attachment[],
     parentId: string | null,
     options?: {
       onUserMessageCreated?: (messageId: string) => void
@@ -402,7 +403,11 @@ export const useConversationStore = defineStore('conversation', () => {
       const initialRoomName = getRoomName(roomId)
       const shouldAutoRename = isFirstUserMessageInRoom && isDefaultRoomName(initialRoomName)
 
-      const content: CommonContentPart[] = [{ type: 'text', text: message }]
+      const pureAttachments = attachments.map((a) => {
+        const { fileName: _, id: __, ...rest } = a
+        return rest
+      })
+      const content: CommonContentPart[] = [{ type: 'text', text: message }, ...pureAttachments]
       const { id } = (await messagesStore.newMessage(
         content,
         'user',

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -33,7 +33,6 @@ export const useMessagesStore = defineStore('messages', () => {
     memory?: string[],
   ) {
     const [message] = await messageModel.create({
-      content,
       role,
       parent_id: parentId,
       provider,

--- a/src/types/attachment.ts
+++ b/src/types/attachment.ts
@@ -1,0 +1,3 @@
+import type { CommonContentPart, TextContentPart } from 'xsai'
+
+export type Attachment = Exclude<CommonContentPart, TextContentPart> & { id: string, fileName: string }


### PR DESCRIPTION
This PR was split to two parts, part 1 is here: #115 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end attachment support (images/audio/files) in chat.
> 
> - New `FileUpload.vue` with drag & drop, limits, type/size validation, previews, and i18n strings; new `AttachmentDisplay.vue` for thumbnail rendering and full-image preview
> - Chat UI (`pages/chat/[id].vue`): attachment toggle, pending preview, allow sending messages with attachments only; integrates `FileUpload` and `AttachmentDisplay`
> - Message rendering: `ConversationView.vue` and `nodes/UserNode.vue` now display non-text parts via `AttachmentDisplay`
> - Data flow: `stores/conversation.ts` `sendMessage` accepts `attachments`, strips UI-only fields, and appends to `content` alongside text; `stores/messages.ts`/`models/messages.ts` adjust create/append flow and typings; new `types/attachment.ts`
> - i18n: added `file_upload.*` keys in `en.yml` and `zh-CN.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fab097b8f70b3c39add7113d49d2d960b6632cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->