### PR TITLE
fix(ui): move `summarize` and `regenerate` button to tool bar

### DIFF
--- a/src/components/nodes/AssistantNode.vue
+++ b/src/components/nodes/AssistantNode.vue
@@ -12,26 +12,13 @@ const props = defineProps<NodeProps<NodeData>>()
 
 const emit = defineEmits<{
   (e: 'abort'): void
-  (e: 'regenerate'): void
-  (e: 'summarize'): void
 }>()
 
 const { defaultTextModel } = storeToRefs(useSettingsStore())
 const messagesStore = useMessagesStore()
 
-const hasSummary = computed(() => !!props.data.message.summary)
 const isGenerating = computed(() => messagesStore.isGenerating(props.data.message.id))
 const showSummary = computed(() => props.data.message.show_summary ?? false)
-
-function toggleSummary() {
-  if (!hasSummary.value && !isGenerating.value) {
-    emit('summarize')
-    void messagesStore.updateShowSummary(props.data.message.id, true) // Switch immediately to show "Summarizing..." or stream
-  }
-  else {
-    void messagesStore.updateShowSummary(props.data.message.id, !showSummary.value)
-  }
-}
 
 // Auto-switch to summary view if summary starts generating
 watch(() => props.data.message.summary, (newVal, oldVal) => {
@@ -55,10 +42,6 @@ watch(() => props.data.message.summary, (newVal, oldVal) => {
       <div>
         <div i-lucide-circle-stop @click="emit('abort')" />
       </div>
-    </div>
-    <div v-if="!messagesStore.isGenerating(data.message.id)" :bg="showSummary ? 'yellow-200 dark:yellow-800' : 'pink-200 dark:pink-800'" flex justify-end gap-2 p-2 class="absolute right-0 top-0 opacity-0 transition-opacity group-hover:opacity-100">
-      <div i-lucide-file-text cursor-pointer text-xs hover:opacity-70 title="Toggle Summary" @click="toggleSummary" />
-      <div i-lucide-refresh-cw cursor-pointer text-xs hover:opacity-70 :title="showSummary ? 'Regenerate Summary' : 'Regenerate'" @click="emit('regenerate')" />
     </div>
     <div v-if="defaultTextModel.provider !== data.message.provider || data.message.model !== defaultTextModel.model" p-2 :bg="showSummary ? 'yellow-200 dark:yellow-800' : 'pink-200 dark:pink-800'">
       {{ data.message.provider }}/{{ data.message.model }}

--- a/src/pages/chat/[id].vue
+++ b/src/pages/chat/[id].vue
@@ -530,6 +530,20 @@ function handleAbort(messageId: string) {
   messagesStore.stopGenerating(messageId)
 }
 
+function handleToolbarRegenerate() {
+  if (!selectedMessageId.value) {
+    return
+  }
+  void handleRegenerate(selectedMessageId.value)
+}
+
+function handleToolbarSummarize() {
+  if (!selectedMessageId.value) {
+    return
+  }
+  void handleSummarize(selectedMessageId.value)
+}
+
 async function handleRegenerate(messageId: string) {
   const message = messagesStore.getMessageById(messageId)
   if (!message)
@@ -678,7 +692,7 @@ onMounted(async () => {
       <Controls />
       <MiniMap :mask-color="strokeColor" zoomable pannable />
       <template #node-assistant="props">
-        <AssistantNode v-bind="props" class="nodrag" @abort="handleAbort(props.id)" @regenerate="handleRegenerate(props.id)" @summarize="handleSummarize(props.id)" />
+        <AssistantNode v-bind="props" class="nodrag" @abort="handleAbort(props.id)" />
       </template>
       <template #node-system="props">
         <SystemNode v-bind="props" class="nodrag" />
@@ -694,6 +708,8 @@ onMounted(async () => {
       @focus-in="handleContextMenuFocusIn"
       @delete="handleContextMenuDelete"
       @copy="handleContextMenuCopy"
+      @regenerate="handleToolbarRegenerate"
+      @summarize="handleToolbarSummarize"
       @send="handleSendButton"
     />
     <div


### PR DESCRIPTION
Move "Summarize" and "Regenerate" buttons for assistant messages to the floating NodeToolbar to consolidate UI actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f1db9f3-44bf-457d-8e84-55e28d8083ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f1db9f3-44bf-457d-8e84-55e28d8083ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

