### PR TITLE
refactor: migrate message content to common content part

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,10 @@ style: better style for markdown view (#53)
 
 ## Code Quality Guidelines
 
+### Code Style
+
+- **Early returns**: Use early returns to reduce nested if statements and improve code readability when possible
+
 ### Type Safety
 
 - **Avoid using `any` type**: Always use proper TypeScript types. Use type inference from libraries (e.g., `InferSelectModel` from drizzle-orm) or define explicit types instead of `any`

--- a/drizzle/0006_premium_golden_guardian.sql
+++ b/drizzle/0006_premium_golden_guardian.sql
@@ -1,0 +1,26 @@
+CREATE TYPE "public"."part_type" AS ENUM('input_audio', 'file', 'image_url', 'text');--> statement-breakpoint
+CREATE TABLE "message_parts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"part_type" "part_type" DEFAULT 'text' NOT NULL,
+	"message_id" uuid NOT NULL,
+	"content" jsonb NOT NULL,
+	"order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "message_parts_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+ALTER TABLE "message_parts" ADD CONSTRAINT "message_parts_message_id_messages_id_fk" FOREIGN KEY ("message_id") REFERENCES "public"."messages"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+-- migrate existing message content to message_parts
+INSERT INTO "message_parts" ("part_type", "message_id", "content", "order", "created_at", "updated_at")
+SELECT
+  'text'::part_type,
+  "id",
+  jsonb_build_object('type', 'text', 'text', "content"),
+  0,
+  "created_at",
+  "updated_at"
+FROM "messages"
+WHERE "content" IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "messages" DROP COLUMN "content";

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,554 @@
+{
+  "id": "11c6d76d-4989-440b-89ca-6c485724728f",
+  "prevId": "a125feea-3d9e-4fba-88f8-7544422b0536",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memories_room_id_rooms_id_fk": {
+          "name": "memories_room_id_rooms_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "memories_id_unique": {
+          "name": "memories_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_parts": {
+      "name": "message_parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "part_type": {
+          "name": "part_type",
+          "type": "part_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_parts_message_id_messages_id_fk": {
+          "name": "message_parts_message_id_messages_id_fk",
+          "tableFrom": "message_parts",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_parts_id_unique": {
+          "name": "message_parts_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_summary": {
+          "name": "show_summary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embeddingIndex": {
+          "name": "embeddingIndex",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_room_id_rooms_id_fk": {
+          "name": "messages_room_id_rooms_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_id_unique": {
+          "name": "messages_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focus_node_id": {
+          "name": "focus_node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_x": {
+          "name": "viewport_x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_y": {
+          "name": "viewport_y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_zoom": {
+          "name": "viewport_zoom",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rooms_template_id_templates_id_fk": {
+          "name": "rooms_template_id_templates_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rooms_id_unique": {
+          "name": "rooms_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "templates_id_unique": {
+          "name": "templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_calls": {
+      "name": "tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_calls_message_id_messages_id_fk": {
+          "name": "tool_calls_message_id_messages_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tool_calls_id_unique": {
+          "name": "tool_calls_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.part_type": {
+      "name": "part_type",
+      "schema": "public",
+      "values": [
+        "input_audio",
+        "file",
+        "image_url",
+        "text"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1766917867180,
       "tag": "0005_sudden_viper",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1768721475671,
+      "tag": "0006_premium_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/MarkdownView.vue
+++ b/src/components/MarkdownView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Pluggable } from 'unified'
+import type { CommonContentPart } from 'xsai'
 import { VueMarkdown } from '@crazydos/vue-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeRaw from 'rehype-raw'
@@ -20,7 +21,7 @@ defineOptions({
 })
 
 const props = defineProps<{
-  content: string
+  content: CommonContentPart[]
 }>()
 
 interface MarkdownSlotMeta extends Record<string, unknown> {
@@ -46,7 +47,7 @@ function getRawMarkdown(meta: MarkdownSlotMeta): string | undefined {
       class="space-y-2"
       of-auto
       break-words
-      :markdown="props.content"
+      :markdown="props.content.filter(part => part.type === 'text').map(part => part.text).join('')"
       :remark-plugins="remarkPlugins"
       :rehype-plugins="rehypePlugins"
     >

--- a/src/components/nodes/AssistantNode.vue
+++ b/src/components/nodes/AssistantNode.vue
@@ -46,6 +46,6 @@ watch(() => props.data.message.summary, (newVal, oldVal) => {
     <div v-if="defaultTextModel.provider !== data.message.provider || data.message.model !== defaultTextModel.model" p-2 :bg="showSummary ? 'yellow-200 dark:yellow-800' : 'pink-200 dark:pink-800'">
       {{ data.message.provider }}/{{ data.message.model }}
     </div>
-    <MarkdownView p-2 :content="showSummary ? (data.message.summary || 'Summarizing...') : data.message.content" />
+    <MarkdownView p-2 :content="showSummary ? [{ type: 'text', text: data.message.summary || 'Summarizing...' }] : data.message.content" />
   </Node>
 </template>

--- a/src/components/nodes/UserNode.vue
+++ b/src/components/nodes/UserNode.vue
@@ -21,6 +21,8 @@ const { defaultTextModel } = storeToRefs(useSettingsStore())
     <div v-if="data.message.provider !== defaultTextModel.provider || data.message.model !== defaultTextModel.model" p-2 bg="sky-200 dark:sky-800">
       @{{ data.message.provider }}/{{ data.message.model }}
     </div>
-    <MarkdownView p-2 :content="data.message.content" />
+    <div p-2>
+      <MarkdownView :content="data.message.content" />
+    </div>
   </Node>
 </template>

--- a/src/models/messages.test.ts
+++ b/src/models/messages.test.ts
@@ -1,7 +1,8 @@
+import type { CommonContentPart } from 'xsai'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useDatabaseStore } from '../stores/database'
-import { useMessageModel } from './messages'
+import { combineMessagesAndParts, useMessageModel } from './messages'
 import { useRoomModel } from './rooms'
 
 describe('message Model', () => {
@@ -9,61 +10,685 @@ describe('message Model', () => {
     setActivePinia(createPinia())
   })
 
-  it('should create an embedding', async () => {
-    const dbStore = useDatabaseStore()
-    await dbStore.initialize(true)
-    await dbStore.migrate()
+  describe('combineMessagesAndParts', () => {
+    it('should combine messages and parts correctly', () => {
+      const messagesAndParts = [
+        {
+          messages: {
+            id: 'msg-1',
+            model: 'test',
+            provider: 'test',
+            role: 'user',
+            room_id: 'room-1',
+            parent_id: null,
+            embedding: null,
+            summary: null,
+            show_summary: false,
+            memory: [],
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+          message_parts: {
+            id: 'part-1',
+            part_type: 'text' as const,
+            message_id: 'msg-1',
+            content: { type: 'text', text: 'Hello' } as CommonContentPart,
+            order: 0,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        },
+        {
+          messages: {
+            id: 'msg-1',
+            model: 'test',
+            provider: 'test',
+            role: 'user',
+            room_id: 'room-1',
+            parent_id: null,
+            embedding: null,
+            summary: null,
+            show_summary: false,
+            memory: [],
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+          message_parts: {
+            id: 'part-2',
+            part_type: 'text' as const,
+            message_id: 'msg-1',
+            content: { type: 'text', text: 'World' } as CommonContentPart,
+            order: 1,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        },
+      ]
 
-    const roomModel = useRoomModel()
-    const room = await roomModel.create('test')
-    const messageModel = useMessageModel()
-    const message = await messageModel.create({
-      model: 'test',
-      provider: 'test',
-      parent_id: null,
-      content: 'FlowChat is a chat UI in graph.',
-      role: 'user',
-      room_id: room.id,
-      summary: null,
+      const result = combineMessagesAndParts(messagesAndParts)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('msg-1')
+      expect(result[0].content).toHaveLength(2)
+      expect(result[0].content[0]).toEqual({ type: 'text', text: 'Hello' })
+      expect(result[0].content[1]).toEqual({ type: 'text', text: 'World' })
     })
-    const embeddingContent = Array.from({ length: 1024 }, () => Math.round(Math.random() * 1000) / 1000)
-    const embedding = await messageModel.updateEmbedding(message.id, embeddingContent)
-    expect(embedding.affectedRows).toBe(1)
+
+    it('should handle messages without parts', () => {
+      const messagesAndParts = [
+        {
+          messages: {
+            id: 'msg-1',
+            model: 'test',
+            provider: 'test',
+            role: 'user',
+            room_id: 'room-1',
+            parent_id: null,
+            embedding: null,
+            summary: null,
+            show_summary: false,
+            memory: [],
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+          message_parts: null,
+        },
+      ]
+
+      const result = combineMessagesAndParts(messagesAndParts)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('msg-1')
+      expect(result[0].content).toHaveLength(0)
+    })
   })
 
-  it('should return not embedded messages', async () => {
-    const dbStore = useDatabaseStore()
-    await dbStore.initialize(true)
-    await dbStore.migrate()
+  describe('the CRUD operations', () => {
+    it('should create a message', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
 
-    const roomModel = useRoomModel()
-    const room = await roomModel.create('test')
-    const messageModel = useMessageModel()
-    const messageHasEmbedding = await messageModel.create({
-      model: 'test',
-      provider: 'test',
-      parent_id: null,
-      content: 'FlowChat is a chat UI in graph.',
-      role: 'user',
-      room_id: room.id,
-      summary: null,
-    })
-    const messageWithoutEmbedding = await messageModel.create({
-      model: 'test',
-      provider: 'test',
-      parent_id: null,
-      content: 'AIRI is a AI companion.',
-      role: 'user',
-      room_id: room.id,
-      summary: null,
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const message = await messageModel.create({
+        model: 'test-model',
+        provider: 'test-provider',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      expect(message).toHaveLength(1)
+      expect(message[0].model).toBe('test-model')
+      expect(message[0].provider).toBe('test-provider')
+      expect(message[0].role).toBe('user')
+      expect(message[0].room_id).toBe(room.id)
     })
 
-    await messageModel.updateEmbedding(
-      messageHasEmbedding.id,
-      Array.from({ length: 1024 }, () => Math.round(Math.random() * 1000) / 1000),
-    )
-    const notEmbeddedMessages = await messageModel.notEmbeddedMessages()
-    expect(notEmbeddedMessages.length).toEqual(1)
-    expect(notEmbeddedMessages[0].id).toEqual(messageWithoutEmbedding.id)
+    it('should get all messages', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'assistant',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const messages = await messageModel.getAll()
+      expect(messages).toHaveLength(2)
+    })
+
+    it('should get messages by room id', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room1 = await roomModel.create('test1')
+      const room2 = await roomModel.create('test2')
+      const messageModel = useMessageModel()
+
+      await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room1.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'assistant',
+        room_id: room2.id,
+        summary: null,
+        memory: [],
+      })
+
+      const room1Messages = await messageModel.getByRoomId(room1.id)
+      expect(room1Messages).toHaveLength(1)
+      expect(room1Messages[0].room_id).toBe(room1.id)
+
+      const room2Messages = await messageModel.getByRoomId(room2.id)
+      expect(room2Messages).toHaveLength(1)
+      expect(room2Messages[0].room_id).toBe(room2.id)
+    })
+
+    it('should update a message', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.update(message.id, {
+        ...message,
+        model: 'updated-model',
+        content: [],
+      })
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].model).toBe('updated-model')
+    })
+
+    it('should delete messages by ids', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message1] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const [message2] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'assistant',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.deleteByIds([message1.id])
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages).toHaveLength(1)
+      expect(messages[0].id).toBe(message2.id)
+    })
+  })
+
+  describe('content operations', () => {
+    it('should append content to a message', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const part: CommonContentPart = { type: 'text', text: 'Hello World' }
+      await messageModel.appendContent(message.id, part)
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].content).toHaveLength(1)
+      expect(messages[0].content[0]).toEqual(part)
+    })
+
+    it('should update content of a message', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const part1: CommonContentPart = { type: 'text', text: 'Hello' }
+      await messageModel.appendContent(message.id, part1)
+
+      const newParts: CommonContentPart[] = [
+        { type: 'text', text: 'Updated' },
+        { type: 'text', text: 'Content' },
+      ]
+      await messageModel.updateContent(message.id, newParts)
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].content).toHaveLength(2)
+      expect(messages[0].content[0]).toEqual(newParts[0])
+      expect(messages[0].content[1]).toEqual(newParts[1])
+    })
+
+    it('should delete content of a message', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const part: CommonContentPart = { type: 'text', text: 'Hello World' }
+      await messageModel.appendContent(message.id, part)
+
+      await messageModel.deleteContent(message.id)
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].content).toHaveLength(0)
+    })
+  })
+
+  describe('summary operations', () => {
+    it('should update summary', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.updateSummary(message.id, 'Test summary')
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].summary).toBe('Test summary')
+    })
+
+    it('should append summary', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: 'Initial',
+        memory: [],
+      })
+
+      await messageModel.appendSummary(message.id, ' summary')
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].summary).toBe('Initial summary')
+    })
+
+    it('should update show_summary flag', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.updateShowSummary(message.id, true)
+
+      const messages = await messageModel.getByRoomId(room.id)
+      expect(messages[0].show_summary).toBe(true)
+    })
+  })
+
+  describe('search operations', () => {
+    it('should search messages by content', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message1] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const [message2] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'assistant',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.appendContent(message1.id, { type: 'text', text: 'FlowChat is awesome' })
+      await messageModel.appendContent(message2.id, { type: 'text', text: 'AIRI is great' })
+
+      const results = await messageModel.searchByContent('FlowChat')
+      expect(results).toHaveLength(1)
+      expect(results[0].id).toBe(message1.id)
+    })
+
+    it('should search messages by content in specific room', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room1 = await roomModel.create('test1')
+      const room2 = await roomModel.create('test2')
+      const messageModel = useMessageModel()
+
+      const [message1] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room1.id,
+        summary: null,
+        memory: [],
+      })
+
+      const [message2] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room2.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.appendContent(message1.id, { type: 'text', text: 'Hello World' })
+      await messageModel.appendContent(message2.id, { type: 'text', text: 'Hello World' })
+
+      const results = await messageModel.searchByContent('Hello', room1.id)
+      expect(results).toHaveLength(1)
+      expect(results[0].id).toBe(message1.id)
+    })
+
+    it('should return empty array when no matches found', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const messageModel = useMessageModel()
+
+      const results = await messageModel.searchByContent('nonexistent')
+      expect(results).toHaveLength(0)
+    })
+  })
+
+  describe('embedding operations', () => {
+    it('should create an embedding', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+      const [message] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+      const embeddingContent = Array.from({ length: 1024 }, () => Math.round(Math.random() * 1000) / 1000)
+      const embedding = await messageModel.updateEmbedding(message.id, embeddingContent)
+      expect(embedding.affectedRows).toBe(1)
+    })
+
+    it('should return not embedded messages', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+      const [messageHasEmbedding] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+      const [messageWithoutEmbedding] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      await messageModel.updateEmbedding(
+        messageHasEmbedding.id,
+        Array.from({ length: 1024 }, () => Math.round(Math.random() * 1000) / 1000),
+      )
+      const notEmbeddedMessages = await messageModel.notEmbeddedMessages()
+      expect(notEmbeddedMessages.length).toEqual(1)
+      expect(notEmbeddedMessages[0].id).toEqual(messageWithoutEmbedding.id)
+    })
+
+    it('should perform vector similarity search', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      const [message1] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const [message2] = await messageModel.create({
+        model: 'test',
+        provider: 'test',
+        parent_id: null,
+        content: [],
+        role: 'user',
+        room_id: room.id,
+        summary: null,
+        memory: [],
+      })
+
+      const embedding1 = Array.from({ length: 1024 }, (_, i) => i % 2 === 0 ? 0.5 : 0.3)
+      const embedding2 = Array.from({ length: 1024 }, (_, i) => i % 2 === 0 ? 0.1 : 0.9)
+
+      await messageModel.updateEmbedding(message1.id, embedding1)
+      await messageModel.updateEmbedding(message2.id, embedding2)
+
+      const results = await messageModel.vectorSimilaritySearch(embedding1, 2)
+
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0]).toHaveProperty('similarity')
+      expect(results[0].id).toBe(message1.id)
+      expect(results[0].similarity).toBeGreaterThan(0.9)
+    })
+
+    it('should return empty array when no embeddings exist', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const messageModel = useMessageModel()
+      const searchEmbedding = Array.from({ length: 1024 }, () => 0.5)
+
+      const results = await messageModel.vectorSimilaritySearch(searchEmbedding, 10)
+      expect(results).toHaveLength(0)
+    })
+
+    it('should limit results by limit parameter', async () => {
+      const dbStore = useDatabaseStore()
+      await dbStore.initialize(true)
+      await dbStore.migrate()
+
+      const roomModel = useRoomModel()
+      const room = await roomModel.create('test')
+      const messageModel = useMessageModel()
+
+      for (let i = 0; i < 5; i++) {
+        const [message] = await messageModel.create({
+          model: 'test',
+          provider: 'test',
+          parent_id: null,
+          content: [],
+          role: 'user',
+          room_id: room.id,
+          summary: null,
+          memory: [],
+        })
+        const embedding = Array.from({ length: 1024 }, () => Math.random())
+        await messageModel.updateEmbedding(message.id, embedding)
+      }
+
+      const searchEmbedding = Array.from({ length: 1024 }, () => 0.5)
+      const results = await messageModel.vectorSimilaritySearch(searchEmbedding, 3)
+
+      expect(results.length).toBeLessThanOrEqual(3)
+    })
   })
 })

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -1,27 +1,48 @@
-import type { InferSelectModel } from 'drizzle-orm'
+import type { CommonContentPart } from 'xsai'
 import type { Message } from '~/types/messages'
-import { and, cosineDistance, desc, eq, getTableColumns, ilike, inArray, isNull, sql } from 'drizzle-orm'
+import { and, asc, cosineDistance, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { useDatabaseStore } from '~/stores/database'
 import * as schema from '../../db/schema'
 
-type MessageRow = InferSelectModel<typeof schema.messages>
+export function combineMessagesAndParts(messagesAndParts: {
+  messages: typeof schema.messages.$inferSelect
+  message_parts: typeof schema.message_parts.$inferSelect | null
+}[]): Message[] {
+  const messagesMap = new Map<string, Message>()
 
-function toMessage(row: MessageRow): Message {
-  return {
-    ...row,
-    memory: row.memory,
+  for (const { messages: message, message_parts: messagePart } of messagesAndParts) {
+    if (!messagesMap.has(message.id)) {
+      messagesMap.set(message.id, {
+        ...message,
+        content: [],
+      })
+    }
+
+    if (messagePart) {
+      const msg = messagesMap.get(message.id)!
+      msg.content.push(messagePart.content)
+    }
   }
+
+  return Array.from(messagesMap.values())
 }
 
 export function useMessageModel() {
   const dbStore = useDatabaseStore()
 
-  function getAll() {
-    return dbStore.db().select().from(schema.messages).then(rows => rows.map(toMessage))
+  async function getAll(roomId?: string): Promise<Message[]> {
+    const messagesAndParts = await dbStore.db()
+      .select()
+      .from(schema.messages)
+      .where(roomId ? eq(schema.messages.room_id, roomId) : undefined)
+      .leftJoin(schema.message_parts, eq(schema.messages.id, schema.message_parts.message_id))
+      .orderBy(asc(schema.messages.created_at), asc(schema.message_parts.order))
+
+    return combineMessagesAndParts(messagesAndParts)
   }
 
   function getByRoomId(roomId: string) {
-    return dbStore.db().select().from(schema.messages).where(eq(schema.messages.room_id, roomId)).then(rows => rows.map(toMessage))
+    return getAll(roomId)
   }
 
   function deleteByIds(ids: string[]) {
@@ -31,11 +52,9 @@ export function useMessageModel() {
   }
 
   async function create(msg: Omit<Message, 'id'>) {
-    const message = await dbStore.withCheckpoint((db) => {
+    return await dbStore.withCheckpoint((db) => {
       return db.insert(schema.messages).values(msg).returning()
     })
-
-    return toMessage(message[0])
   }
 
   function update(id: string, msg: Message) {
@@ -44,17 +63,59 @@ export function useMessageModel() {
     })
   }
 
-  function appendContent(id: string, content: string | string[]) {
-    const contentToAppend = Array.isArray(content) ? content.join('') : content
-
+  function appendContent(message_id: string, part: CommonContentPart) {
     return dbStore.withCheckpoint((db) => {
-      return db.execute(sql`UPDATE messages SET content = content || ${contentToAppend} WHERE id = ${id}`)
+      return db.execute(sql`
+        INSERT INTO message_parts (message_id, part_type, content, "order")
+        VALUES (
+          ${message_id},
+          ${part.type}::part_type,
+          ${JSON.stringify(part)}::jsonb,
+          COALESCE((
+            SELECT MAX("order") + 1
+            FROM message_parts
+            WHERE message_id = ${message_id}
+          ), 0)
+        )
+      `)
     })
   }
 
-  function updateContent(id: string, content: string) {
+  async function appendContentBatch(message_id: string, parts: CommonContentPart[]) {
+    return await dbStore.withCheckpoint(async (db) => {
+      const result = await db
+        .select({ maxOrder: sql<number>`COALESCE(MAX("order"), -1)` })
+        .from(schema.message_parts)
+        .where(eq(schema.message_parts.message_id, message_id))
+
+      const startOrder = (result[0]?.maxOrder ?? -1) + 1
+
+      return db.insert(schema.message_parts).values(
+        parts.map((part, index) => ({
+          message_id,
+          part_type: part.type,
+          content: part,
+          order: startOrder + index,
+        })),
+      )
+    })
+  }
+
+  function deleteContent(message_id: string) {
     return dbStore.withCheckpoint((db) => {
-      return db.update(schema.messages).set({ content }).where(eq(schema.messages.id, id))
+      return db.delete(schema.message_parts).where(eq(schema.message_parts.message_id, message_id))
+    })
+  }
+
+  async function updateContent(message_id: string, parts: CommonContentPart[]) {
+    await deleteContent(message_id)
+
+    if (parts.length === 0) {
+      return
+    }
+
+    return dbStore.withCheckpoint(async (db) => {
+      await db.insert(schema.message_parts).values(parts.map(part => ({ message_id, part_type: part.type, content: part, order: parts.indexOf(part) })))
     })
   }
 
@@ -75,22 +136,28 @@ export function useMessageModel() {
       return db.update(schema.messages).set({ show_summary }).where(eq(schema.messages.id, id))
     })
   }
-  function searchByContent(keyword: string, roomId?: string) {
-    const conditions = [ilike(schema.messages.content, `%${keyword}%`)]
 
-    if (roomId) {
-      conditions.push(eq(schema.messages.room_id, roomId))
+  async function searchByContent(keyword: string, roomId?: string): Promise<Message[]> {
+    const conditions = roomId ? [eq(schema.messages.room_id, roomId)] : []
+
+    const messagesAndParts = await dbStore.db()
+      .selectDistinct({ messages: schema.messages, message_parts: schema.message_parts })
+      .from(schema.message_parts)
+      .innerJoin(schema.messages, eq(schema.message_parts.message_id, schema.messages.id))
+      .where(and(
+        sql`${schema.message_parts.content}::text ILIKE ${`%${keyword}%`}`,
+        ...conditions,
+      ))
+
+    if (messagesAndParts.length === 0) {
+      return []
     }
 
-    return dbStore.db()
-      .select()
-      .from(schema.messages)
-      .where(and(...conditions))
-      .then(rows => rows.map(toMessage))
+    return combineMessagesAndParts(messagesAndParts)
   }
 
   function notEmbeddedMessages() {
-    return dbStore.db().select().from(schema.messages).where(isNull(schema.messages.embedding)).then(rows => rows.map(toMessage))
+    return dbStore.db().select().from(schema.messages).where(isNull(schema.messages.embedding))
   }
 
   function updateEmbedding(id: string, embedding: number[]) {
@@ -99,14 +166,34 @@ export function useMessageModel() {
     })
   }
 
-  function vectorSimilaritySearch(embedding: number[], limit: number = 10) {
+  async function vectorSimilaritySearch(embedding: number[], limit: number = 10) {
     const similarity = sql<number>`1 - (${cosineDistance(schema.messages.embedding, embedding)})`
-    return dbStore.db()
-      .select({ similarity, ...getTableColumns(schema.messages) })
+
+    const topMessages = await dbStore.db()
+      .select({ id: schema.messages.id, similarity })
       .from(schema.messages)
-      .orderBy(t => desc(t.similarity))
+      .orderBy(desc(similarity))
       .limit(limit)
-      .then(rows => rows.map(row => ({ ...toMessage(row), similarity: row.similarity })))
+
+    if (topMessages.length === 0) {
+      return []
+    }
+
+    const messageIds = topMessages.map(m => m.id)
+    const similarityMap = new Map(topMessages.map(m => [m.id, m.similarity]))
+
+    const messagesAndParts = await dbStore.db()
+      .select()
+      .from(schema.messages)
+      .where(inArray(schema.messages.id, messageIds))
+      .leftJoin(schema.message_parts, eq(schema.messages.id, schema.message_parts.message_id))
+      .orderBy(asc(schema.message_parts.order))
+
+    const messages = combineMessagesAndParts(messagesAndParts)
+
+    return messages
+      .map(msg => ({ ...msg, similarity: similarityMap.get(msg.id) ?? 0 }))
+      .sort((a, b) => b.similarity - a.similarity)
   }
 
   return {
@@ -116,11 +203,13 @@ export function useMessageModel() {
     create,
     update,
     appendContent,
+    appendContentBatch,
     searchByContent,
     notEmbeddedMessages,
     updateEmbedding,
     vectorSimilaritySearch,
     updateContent,
+    deleteContent,
     appendSummary,
     updateSummary,
     updateShowSummary,

--- a/src/stores/conversation.ts
+++ b/src/stores/conversation.ts
@@ -5,7 +5,6 @@ import type {
 } from '@moeru-ai/jem'
 import type { CommonContentPart } from 'xsai'
 import type { BaseMessage } from '~/types/messages'
-import { hasCapabilities } from '@moeru-ai/jem'
 import { defineStore, storeToRefs } from 'pinia'
 import { ref } from 'vue'
 import { toast } from 'vue-sonner'
@@ -231,12 +230,12 @@ export const useConversationStore = defineStore('conversation', () => {
         ],
       }
 
-      // const capabilities: Record<string, boolean> = hasCapabilities(
-      //   provider as ProviderNames,
-      //   model as ModelIdsByProvider<ProviderNames>,
-      //   ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
-      // )
-      // const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
+      const capabilities: Record<string, boolean> = hasCapabilities(
+        provider as ProviderNames,
+        model as ModelIdsByProvider<ProviderNames>,
+        ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
+      )
+      const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
 
       const branch = messagesStore.getBranchById(parentId)
       const conversationMessages = branch.messages
@@ -249,7 +248,7 @@ export const useConversationStore = defineStore('conversation', () => {
       } satisfies BaseMessage, ...conversationMessages]))
 
       const { textStream, reasoningTextStream } = streamText({
-        // ...(isSupportTools ? tools : {}),
+        ...(isSupportTools ? tools : {}),
         maxSteps: 10,
         apiKey: currentProvider.value?.apiKey,
         baseURL: currentProvider.value?.baseURL,
@@ -404,7 +403,6 @@ export const useConversationStore = defineStore('conversation', () => {
       const shouldAutoRename = isFirstUserMessageInRoom && isDefaultRoomName(initialRoomName)
 
       const content: CommonContentPart[] = [{ type: 'text', text: message }]
-      console.log('newMessage', content)
       const { id } = (await messagesStore.newMessage(
         content,
         'user',

--- a/src/stores/conversation.ts
+++ b/src/stores/conversation.ts
@@ -3,6 +3,7 @@ import type {
   ModelIdsByProvider,
   ProviderNames,
 } from '@moeru-ai/jem'
+import type { CommonContentPart } from 'xsai'
 import type { BaseMessage } from '~/types/messages'
 import { hasCapabilities } from '@moeru-ai/jem'
 import { defineStore, storeToRefs } from 'pinia'
@@ -27,32 +28,36 @@ export const useConversationStore = defineStore('conversation', () => {
   const streamTextAbortControllers = ref<Map<string, AbortController>>(new Map())
   const streamTextRunIds = ref<Map<string, number>>(new Map())
   const sendingRooms = ref<Set<string>>(new Set())
-  const tokensBuffers = ref<Map<string, string[]>>(new Map())
+  const messagePartBuffers = ref<Map<string, CommonContentPart[]>>(new Map())
 
   const systemPrompt = useSystemPrompt()
 
-  async function saveToTokensBuffer(messageId: string, text: string, _reasoning: boolean = false) {
-    const tokensBuffer = tokensBuffers.value.get(messageId)
-    if (!tokensBuffer) {
-      tokensBuffers.value.set(messageId, [text])
+  async function saveMessagePartToBuffer(messageId: string, part: CommonContentPart) {
+    const messagePartBuffer = messagePartBuffers.value.get(messageId)
+    if (!messagePartBuffer) {
+      messagePartBuffers.value.set(messageId, [part])
       return
     }
 
-    tokensBuffer.push(text)
+    messagePartBuffer.push(part)
   }
 
-  async function checkAndFlushTokensBuffer(messageId: string, forceFlush: boolean = false) {
-    const tokensBuffer = tokensBuffers.value.get(messageId)
-    if (!tokensBuffer) {
+  async function checkAndFlushMessagePartBuffer(messageId: string, forceFlush: boolean = false) {
+    const messagePartBuffer = messagePartBuffers.value.get(messageId)
+    if (!messagePartBuffer) {
       return
     }
 
-    if (!forceFlush && tokensBuffer.length < 20) {
+    if (messagePartBuffer.length === 0) {
       return
     }
 
-    await messagesStore.appendContent(messageId, tokensBuffer)
-    tokensBuffer.length = 0
+    if (!forceFlush && messagePartBuffer.length < 20) {
+      return
+    }
+
+    await messagesStore.appendContent(messageId, messagePartBuffer)
+    messagePartBuffer.length = 0
     await messagesStore.retrieveMessages()
   }
 
@@ -121,8 +126,9 @@ export const useConversationStore = defineStore('conversation', () => {
       return
 
     const assistant = messagesStore.getMessageById(assistantMessageId)
-    const assistantContent = assistant?.content || ''
-    if (!assistantContent.trim())
+
+    const assistantContent = assistant?.content || [{ text: '', type: 'text' }]
+    if (!assistantContent[0])
       return
 
     const context = `User:\n${firstUserMessage}\n\nAssistant:\n${assistantContent}`
@@ -144,8 +150,8 @@ export const useConversationStore = defineStore('conversation', () => {
     reasoning: boolean = false,
   ) {
     if (reasoning) {
-      await saveToTokensBuffer(newMsgId, '<think>\n', reasoning)
-      await checkAndFlushTokensBuffer(newMsgId, true)
+      await saveMessagePartToBuffer(newMsgId, { type: 'text', text: '<think>\n' })
+      await checkAndFlushMessagePartBuffer(newMsgId, true)
     }
 
     for await (const textPart of asyncIteratorFromReadableStream(stream, async v => v)) {
@@ -153,17 +159,17 @@ export const useConversationStore = defineStore('conversation', () => {
         break
 
       if (textPart && textPart.trim()) {
-        await saveToTokensBuffer(newMsgId, textPart)
-        await checkAndFlushTokensBuffer(newMsgId)
+        await saveMessagePartToBuffer(newMsgId, { type: 'text', text: textPart })
+        await checkAndFlushMessagePartBuffer(newMsgId)
       }
     }
 
     if (reasoning) {
-      await saveToTokensBuffer(newMsgId, '\n</think>\n', reasoning)
-      await checkAndFlushTokensBuffer(newMsgId, true)
+      await saveMessagePartToBuffer(newMsgId, { type: 'text', text: '\n</think>\n' })
+      await checkAndFlushMessagePartBuffer(newMsgId, true)
     }
 
-    await checkAndFlushTokensBuffer(newMsgId, true)
+    await checkAndFlushMessagePartBuffer(newMsgId, true)
   }
 
   async function generateResponse(
@@ -191,10 +197,11 @@ export const useConversationStore = defineStore('conversation', () => {
     let newMsgId: string
     if (regenerateId) {
       newMsgId = regenerateId
-      await messagesStore.setContent(newMsgId, '')
+      await messagesStore.updateContent(newMsgId, [])
     }
     else {
-      const { id } = await messagesStore.newMessage('', 'assistant', parentId, provider, model, roomId, systemPromptResult.memoryIds)
+      const { id } = (await messagesStore.newMessage([], 'assistant', parentId, provider, model, roomId, systemPromptResult.memoryIds))
+      await messagesStore.retrieveMessages()
       newMsgId = id
     }
 
@@ -224,25 +231,25 @@ export const useConversationStore = defineStore('conversation', () => {
         ],
       }
 
-      const capabilities: Record<string, boolean> = hasCapabilities(
-        provider as ProviderNames,
-        model as ModelIdsByProvider<ProviderNames>,
-        ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
-      )
-      const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
+      // const capabilities: Record<string, boolean> = hasCapabilities(
+      //   provider as ProviderNames,
+      //   model as ModelIdsByProvider<ProviderNames>,
+      //   ['tool-call'] as CapabilitiesByModel<ProviderNames, ModelIdsByProvider<ProviderNames>>,
+      // )
+      // const isSupportTools = capabilities['tool-call'] // FIXME: JEM catalog needs to be updated
 
       const branch = messagesStore.getBranchById(parentId)
       const conversationMessages = branch.messages
         .filter(msg => msg.role !== 'system')
         .map(({ content, role }): BaseMessage => ({ content, role }))
 
-      const allMessages = [{
-        content: systemPromptResult.prompt,
+      const allMessages = JSON.parse(JSON.stringify([{
+        content: [{ type: 'text', text: systemPromptResult.prompt }],
         role: 'system',
-      } satisfies BaseMessage, ...conversationMessages]
+      } satisfies BaseMessage, ...conversationMessages]))
 
       const { textStream, reasoningTextStream } = streamText({
-        ...(isSupportTools ? tools : {}),
+        // ...(isSupportTools ? tools : {}),
         maxSteps: 10,
         apiKey: currentProvider.value?.apiKey,
         baseURL: currentProvider.value?.baseURL,
@@ -396,14 +403,17 @@ export const useConversationStore = defineStore('conversation', () => {
       const initialRoomName = getRoomName(roomId)
       const shouldAutoRename = isFirstUserMessageInRoom && isDefaultRoomName(initialRoomName)
 
-      const { id } = await messagesStore.newMessage(
-        message,
+      const content: CommonContentPart[] = [{ type: 'text', text: message }]
+      console.log('newMessage', content)
+      const { id } = (await messagesStore.newMessage(
+        content,
         'user',
         parentId,
         defaultTextModel.value.provider,
         model ?? defaultTextModel.value.model,
         roomId,
-      )
+        undefined,
+      ))
       await messagesStore.retrieveMessages()
 
       options?.onUserMessageCreated?.(id)
@@ -485,7 +495,7 @@ export const useConversationStore = defineStore('conversation', () => {
     isSending,
     isGeneratingMessage,
     hasGeneratingAncestor,
-    saveToTokensBuffer,
-    checkAndFlushTokensBuffer,
+    saveMessagePartToBuffer,
+    checkAndFlushMessagePartBuffer,
   }
 })

--- a/src/tools/with-tool-call-log.ts
+++ b/src/tools/with-tool-call-log.ts
@@ -25,12 +25,12 @@ export async function withToolCallLog<T>(
 
   try {
     const result = await execute()
-    conversationStore.checkAndFlushTokensBuffer(options.messageId, true) // force flush tokens buffer when receive any tool calls
+    conversationStore.checkAndFlushMessagePartBuffer(options.messageId, true) // force flush message part buffer when receive any tool calls
 
     await toolCallModel.updateResult(toolCall.id, result)
 
     const toolCallMarkdown = `\n\n:::tool-call ${toolCall.id}:::\n\n`
-    await messagesStore.appendContent(options.messageId, toolCallMarkdown)
+    await messagesStore.appendContent(options.messageId, { type: 'text', text: toolCallMarkdown })
 
     return result
   }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,7 +1,9 @@
+import type { CommonContentPart } from 'xsai'
+
 export type MessageRole = 'user' | 'assistant' | 'system'
 
 export interface BaseMessage {
-  content: string
+  content: CommonContentPart[]
   role: string // FIXME: use enum in pglite
 }
 

--- a/src/utils/tutorial.ts
+++ b/src/utils/tutorial.ts
@@ -33,6 +33,7 @@ function createMessage(
     model,
     provider,
     summary: null,
+    attachments: [],
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates message storage and rendering from plain text to structured, ordered parts.
> 
> - **DB schema**: Add `part_type` enum and `message_parts` table; backfill from `messages.content` and drop the column
> - **Models/queries**: New `combineMessagesAndParts`; CRUD for parts (`appendContent`, batch, update, delete); search by part content; vector similarity fetch joins parts; optional room-scoped `getAll`
> - **Stores/streaming**: Switch to `CommonContentPart[]`; buffer and flush message parts during streaming; adjust message creation/regenerate flows; summary/update flags unchanged
> - **UI**: `MarkdownView` now consumes parts and renders joined text segments; Conversation/User/Assistant nodes and copy actions updated; chat input layout tweaks
> - **Tests**: Extensive unit tests for combining, CRUD, search, embeddings, and similarity results
> - **Docs**: AGENTS.md adds code style and migration consolidation guidance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d8e78781efc769ea0b1d6f4d0d4e7ad1108022f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->